### PR TITLE
Add a fake Cortex that can use HTTP instead of Telepath

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 synapse = "*"
+aiohttp = "*"
 
 [dev-packages]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stormlibpp"
-version = "0.3.1"
+version = "0.4.0"
 description = "The stormlibpp Python package"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/stormlibpp/__init__.py
+++ b/src/stormlibpp/__init__.py
@@ -29,11 +29,12 @@ are briefly described below:
 
 """
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 # TODO - Do we want to change this to only import submods, or do we even need that?
 from . import errors
 from . import utils
+from .httpcore import HttpCortex
 from .node import StormNode
 from .stormpkg import StormPkg
 from .telepath import (genDefaultTelepathRetn, TelepathRetn)

--- a/src/stormlibpp/errors.py
+++ b/src/stormlibpp/errors.py
@@ -22,3 +22,9 @@ class StormPkgBadDefError(StormPkgError):
 
 class StormPkgSyntaxError(StormPkgError, StormSyntaxError):
     """The Storm code defined in a StormPkg has a syntax error."""
+
+class HttpCortexError(Exception):
+    """An error occurred in HttpCortex."""
+
+class HttpCortexLoginError(HttpCortexError):
+    """Unable to login to Synapse with HttpCortex."""

--- a/src/stormlibpp/httpcore.py
+++ b/src/stormlibpp/httpcore.py
@@ -32,7 +32,7 @@ class HttpCortex:
         )
 
     async def __aenter__(self):
-        await self.start()
+        await self.login()
         return self
 
     async def __aexit__(self, *args, **kwargs):
@@ -76,11 +76,15 @@ class HttpCortex:
             code = item.get("code")
             mesg = item.get("mesg")
             raise HttpCortexLoginError(f"Login error ({code}): {mesg}")
+        
+        session_cookie = resp.cookies.get("sess")
 
-    async def start(self):
-        """Start this instance by initializing the HTTP session and logging in."""
+        if session_cookie is None:
+            raise HttpCortexLoginError(
+                "Successfully authenticated but Synapse did not send session cookie"
+            )
 
-        await self.login()
+        self.sess.cookie_jar.update_cookies({"sess": session_cookie.value})
 
     async def stop(self):
         await self.sess.close()

--- a/src/stormlibpp/httpcore.py
+++ b/src/stormlibpp/httpcore.py
@@ -1,0 +1,105 @@
+"""Implements some methods from synapse.cortex.Cortex but with HTTP."""
+
+
+import aiohttp
+import json
+
+from .errors import HttpCortexError, HttpCortexLoginError
+
+
+class HttpCortex:
+    """A class with some methods from synapse.cortex.Cortex but over HTTP."""
+
+    def __init__(
+        self,
+        url: str = "https://localhost:4443",
+        usr: str = "",
+        pwd: str = "",
+        default_opts: dict = {"repr": True},
+        ssl_verify: bool = True,
+    ) -> None:
+
+        self.url = url
+        self.ssl_verify = ssl_verify
+        self.default_opts = default_opts
+
+        self.usr = usr
+        self.pwd = pwd
+
+        self.timeout = aiohttp.ClientTimeout(60.0, 10.0)
+        self.sess = aiohttp.ClientSession(
+            self.url, timeout=self.timeout, raise_for_status=True
+        )
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        await self.stop()
+
+    def _prep_payload(self, text: str, opts: dict | None = None):
+        if not opts:
+            opts = self.default_opts
+        return {"query": text, "opts": opts}
+
+    async def callStorm(self, text: str, opts: dict | None = None):
+        """Execute a Storm query and return the value passed to a Storm return() call."""
+
+        url = "/api/v1/storm/call"
+
+        data = self._prep_payload(text, opts=opts)
+
+        try:
+            async with self.sess.get(url, json=data, ssl=self.ssl_verify) as resp:
+                data = await resp.json()
+                return data
+        except Exception as err:
+            raise HttpCortexError(
+                f"Unable to call storm on {self.url}: {err}", err
+            ) from err
+    
+    async def login(self):
+
+        info = {"user": self.usr, "passwd": self.pwd}
+        url = "/api/v1/login"
+
+        try:
+            async with self.sess.post(url, json=info, ssl=self.ssl_verify) as resp:
+                item = await resp.json()
+        except Exception as err:
+            raise HttpCortexLoginError(
+                f"Error making login request to {self.url}: {err}", err
+            ) from err
+
+        if item.get("status") != "ok":
+            code = item.get("code")
+            mesg = item.get("mesg")
+            raise HttpCortexLoginError(f"Login error ({code}): {mesg}")
+
+    async def start(self):
+        """Start this instance by initializing the HTTP session and logging in."""
+
+        await self.login()
+
+    async def stop(self):
+        await self.sess.close()
+
+    async def storm(self, text: str, opts: dict | None = None):
+        """Evaulate a Storm query and yield the streamed Storm messages."""
+
+        url = "/api/v1/storm"
+
+        data = self._prep_payload(text, opts=opts)
+
+        try:
+            async with self.sess.get(url, json=data, ssl=self.ssl_verify) as resp:
+                async for byts, _ in resp.content.iter_chunks():
+                    if not byts:
+                        break
+
+                    yield json.loads(byts)
+        except Exception as err:
+            raise HttpCortexError(
+                f"Unable to execute storm on {self.url}: {err}", err
+            ) from err

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""StormLib++ pytest suite."""

--- a/tests/test_httpcore.py
+++ b/tests/test_httpcore.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import synapse.tests.utils as s_test
+
+import stormlibpp
+
+
+class TestHttpCore(s_test.SynTest):
+    async def test_login(self):
+        async with self.getTestCore(conf={"https:port": 4443}) as core:
+            await core.addUser("test", passwd="test")
+
+            async with stormlibpp.HttpCortex(
+                "https://127.0.0.1:4443", ssl_verify=False, usr="test", pwd="test"
+            ) as hcore:
+                return
+
+    async def test_storm(self):
+        async with self.getTestCore(conf={"https:port": 4443}) as core:
+            await core.addUser("test", passwd="test")
+
+            async with stormlibpp.HttpCortex(
+                "https://127.0.0.1:4443", ssl_verify=False, usr="test", pwd="test"
+            ) as hcore:
+                msgs = []
+                async for msg in hcore.storm("help"):
+                    msgs.append(msg)
+                print(msgs)
+                self.stormHasNoWarnErr(msgs)

--- a/tests/test_httpcore.py
+++ b/tests/test_httpcore.py
@@ -1,6 +1,3 @@
-import os
-import sys
-
 import synapse.tests.utils as s_test
 
 import stormlibpp
@@ -14,7 +11,17 @@ class TestHttpCore(s_test.SynTest):
             async with stormlibpp.HttpCortex(
                 "https://127.0.0.1:4443", ssl_verify=False, usr="test", pwd="test"
             ) as hcore:
-                return
+                assert hcore.sess.cookie_jar._cookies != {}
+
+    async def test_callStorm(self):
+        async with self.getTestCore(conf={"https:port": 4443}) as core:
+            await core.addUser("test", passwd="test")
+
+            async with stormlibpp.HttpCortex(
+                "https://127.0.0.1:4443", ssl_verify=False, usr="test", pwd="test"
+            ) as hcore:
+                retn = await hcore.callStorm("return('test')")
+                assert retn["result"] == "test"
 
     async def test_storm(self):
         async with self.getTestCore(conf={"https:port": 4443}) as core:
@@ -26,5 +33,4 @@ class TestHttpCore(s_test.SynTest):
                 msgs = []
                 async for msg in hcore.storm("help"):
                     msgs.append(msg)
-                print(msgs)
                 self.stormHasNoWarnErr(msgs)


### PR DESCRIPTION
The fake object only reimplements the `storm` and `callStorm` methods.