### PR TITLE
fix: don't timeout in httpcore (#17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stormlibpp"
-version = "0.6.4"
+version = "0.7.0"
 description = "The stormlibpp Python package"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/stormlibpp/__init__.py
+++ b/src/stormlibpp/__init__.py
@@ -46,7 +46,7 @@ that can be used for testing other tools. It creates a user (``test``) with pass
 script will support custom Cortex configuration.
 """
 
-__version__ = "0.6.4"
+__version__ = "0.7.0"
 
 # TODO - Do we want to change this to only import submods, or do we even need that?
 from . import errors

--- a/src/stormlibpp/httpcore.py
+++ b/src/stormlibpp/httpcore.py
@@ -110,9 +110,8 @@ class HttpCortex:
         self.usr = usr
         self.pwd = pwd
 
-        self.timeout = aiohttp.ClientTimeout(60.0, 10.0)
         self.sess = aiohttp.ClientSession(
-            self.url, timeout=self.timeout, raise_for_status=True
+            self.url, raise_for_status=True, read_timeout=0
         )
 
     async def __aenter__(self):


### PR DESCRIPTION
`httpcore` set a timeout, however this was being enforced even while actively streaming messages back from the Cortex. This PR removes any timeout in `httpcore` so that queries may run for as long as needed.