### PR TITLE
Fix type() misuse in utils.py

### DIFF
--- a/src/stormlibpp/utils.py
+++ b/src/stormlibpp/utils.py
@@ -97,7 +97,7 @@ def json_genr(fd):
     # TODO - Support nested key to start with
     data = json.load(fd)
 
-    if type(data, dict):
+    if isinstance(data, dict):
         for key, row in data.items():
             yield [key, row]
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@
 
 
 import stormlibpp
+import io
+import json
 
 
 class TestNormVer:
@@ -17,3 +19,23 @@ class TestNormVer:
         verstr, vertup = stormlibpp.utils.normver(ver)
         assert vertup == ver
         assert verstr == "1.2.3"
+
+
+class TestJsonGenr:
+    def test_json_genr_dict(self):
+        input = {"proto": "http", "host": "1.2.3.4"}
+        fd = io.StringIO(json.dumps(input))
+
+        for k, v in stormlibpp.utils.json_genr(fd):
+            assert k in input
+            assert v in input.values()
+
+
+    def test_json_genr_list(self):
+        input = ["1.2.3.4", "1.2.3.5"]
+        fd = io.StringIO(json.dumps(input))
+
+        gen = stormlibpp.utils.json_genr(fd)
+
+        assert next(gen) == [0, input[0]]
+        assert next(gen) == [1, input[1]]


### PR DESCRIPTION
JSON imports are not working at the moment because of a bug in `utils.py` within `json_genr` function.

The function `type()` is currently used with 2 arguments and this is unfortunately not a supported signature.
The right way seems to use `isinstance(obj, class)` in order to determine the current type.

Let me know if this needs other changes 😄 