### PR TITLE
feat: add an http based synapse.tools.feed wrapper

### DIFF
--- a/src/stormlibpp/_args.py
+++ b/src/stormlibpp/_args.py
@@ -3,6 +3,18 @@
 
 import argparse
 
+
+TOKEN_PARSER = argparse.ArgumentParser(add_help=False)
+TOKEN_PARSER.add_argument(
+    "--token",
+    action="store_true",
+    help=(
+        "Use token-based authentication when connecting over HTTP. Reads the"
+        " CORTEX_TOKEN environment variable for the token value. The token is"
+        " prompted for if the environment variable is empty."
+    ),
+)
+
 USER_PARSER = argparse.ArgumentParser(add_help=False)
 USER_PARSER.add_argument(
     "--user",
@@ -13,4 +25,11 @@ USER_PARSER.add_argument(
         " input a value or accept the default (return of getpass.getpass()). Only"
         " works when connecting to a Cortex over HTTP."
     ),
+)
+
+VERIFY_PARSER = argparse.ArgumentParser(add_help=False)
+VERIFY_PARSER.add_argument(
+    "--no-verify",
+    help="Skips verification of the Cortex's SSL certificate when using HTTP.",
+    action="store_true",
 )

--- a/src/stormlibpp/hfeed.py
+++ b/src/stormlibpp/hfeed.py
@@ -1,0 +1,73 @@
+"""A wrapper of ``synapse.tools.feed`` that feeds data to a Cortex over HTTP instead of Telepath."""
+
+
+import asyncio
+import sys
+
+import synapse.tools.feed as s_feed
+
+from ._args import TOKEN_PARSER, USER_PARSER, VERIFY_PARSER
+from .output import OUTP
+from .utils import add_parser_parents
+from .utils import (
+    add_parser_parents,
+    get_cortex_creds,
+    get_cortex_obj,
+    get_cortex_token,
+)
+
+
+def get_args(argv: list[str]):
+    parser = s_feed.makeargparser()
+    parser.prog = "stormlibpp.hfeed"
+    parser.description = __doc__
+
+    parents =  [TOKEN_PARSER, USER_PARSER, VERIFY_PARSER]
+    parser = add_parser_parents(parser, parents)
+
+    return parser.parse_args(argv)
+
+
+async def main():
+    args = get_args(sys.argv[1:])
+
+    if args.token and not args.test:
+        token = get_cortex_token(prompt=True)
+        username = password = ""
+        if not token:
+            return "Token wasn't set!"
+    elif not args.test:
+        username, password = get_cortex_creds(args.user)
+        token = ""
+        if not username or not password:
+            return "Username/password wasn't set!"
+    else:
+        token = username = password = ""
+
+    # TODO - Support telepath too?
+    core_obj = await get_cortex_obj(
+        cortex=args.cortex,
+        local=args.test,
+        http=True,
+        ssl_verify=not args.no_verify,
+        username=username,
+        password=password,
+        token=token,
+    )
+
+    async with core_obj() as core:
+
+        await s_feed.addFeedData(
+            core,
+            OUTP,
+            args.format,
+            args.debug,
+            chunksize=args.chunksize,
+            offset=args.offset,
+            viewiden=args.view,
+            *args.files
+        )
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(asyncio.run(main()))

--- a/src/stormlibpp/httpcore.py
+++ b/src/stormlibpp/httpcore.py
@@ -92,6 +92,8 @@ class HttpCortex:
         The username to authenticate with, by default `""`.
     pwd : str, optional
         The password to authenticate with, by default `""`.
+    token : str, optional
+        A token to authenticate with, instead of usr/pwd, by default `""`.
     default_opts : dict, optional
         The default Storm options to pass with every request made by this instance.
         Set this to an empty dict to disable. By default `{"repr": True}`.

--- a/src/stormlibpp/httpcore.py
+++ b/src/stormlibpp/httpcore.py
@@ -168,12 +168,6 @@ class HttpCortex:
 
         url = "/api/v1/feed"
 
-        # Convert bytes items to NodeTuples for JSON compatibility.
-        items = list(items)
-        for index in range(len(items)):
-            if isinstance(items[index], bytes):
-                items[index] = s_msgpack.un(items[index])
-
         data = {"items": items}
 
         if viewiden is not None:
@@ -265,7 +259,7 @@ class HttpCortex:
         try:
             async with self.sess.get(url, json=payload, ssl=self.ssl_verify) as resp:
                 data = await resp.read()
-                yield data
+                yield s_msgpack.un(data)
         except Exception as err:
             raise HttpCortexError(f"Unable to export nodes: {err}", err) from err
 

--- a/src/stormlibpp/httpcore.py
+++ b/src/stormlibpp/httpcore.py
@@ -165,7 +165,14 @@ class HttpCortex:
             This will likely either be from an HTTP error, a connection error,
             or an error decoding the JSON response.
         """
+
         url = "/api/v1/feed"
+
+        # Convert bytes items to NodeTuples for JSON compatibility.
+        items = list(items)
+        for index in range(len(items)):
+            if isinstance(items[index], bytes):
+                items[index] = s_msgpack.un(items[index])
 
         data = {"items": items}
 
@@ -173,7 +180,7 @@ class HttpCortex:
             data["view"] = viewiden
 
         if name:
-            data = {"name": name}
+            data["name"] = name
 
         try:
             async with self.sess.post(url, json=data, ssl=self.ssl_verify) as resp:

--- a/src/stormlibpp/import.py
+++ b/src/stormlibpp/import.py
@@ -73,7 +73,7 @@ import synapse.common as s_common
 import synapse.telepath as s_telepath
 import yaml
 
-from ._args import USER_PARSER
+from ._args import USER_PARSER, VERIFY_PARSER
 from .httpcore import HttpCortex
 from .output import handle_msg, log_storm_msg, OUTP
 from .stormcli import start_storm_cli
@@ -239,7 +239,7 @@ def find_data_files(orig: str, files: list[str]) -> tuple[str, str]:
 def get_args(argv: list[str]):
     parser = argparse.ArgumentParser(
         description=DESCRIPTION,
-        parents=[USER_PARSER],
+        parents=[USER_PARSER, VERIFY_PARSER],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
@@ -279,11 +279,6 @@ def get_args(argv: list[str]):
             "Start a temp Cortex locally to execute the Storm scripts"
             " on and enter a CLI for afterwards"
         ),
-        action="store_true",
-    )
-    parser.add_argument(
-        "--no-verify",
-        help="Skips verification of the Cortex's certificate when using --http",
         action="store_true",
     )
     parser.add_argument(

--- a/src/stormlibpp/node.py
+++ b/src/stormlibpp/node.py
@@ -1,7 +1,6 @@
 """Work with storm:node objects in Python."""
 
 
-from types import SimpleNamespace
 from typing import Any, TypedDict
 
 
@@ -67,8 +66,8 @@ class ItemContainer:
     To convert this object to a ``dict`` of the items it holds,
     call ``vars`` on an instance.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     All keyword args passed at instantiation are added to the container as initial
     values. These are not required and no args passed just creates an empty container.
     """


### PR DESCRIPTION
This PR adds an `hfeed` tool that wraps the builtin `synapse.tools.feed` but uses HTTP for communication.