### PR TITLE
fix(#26): gracefully quit on auth failures in hstorm

### DIFF
--- a/src/stormlibpp/hstorm.py
+++ b/src/stormlibpp/hstorm.py
@@ -24,6 +24,7 @@ import argparse
 import sys
 
 from ._args import USER_PARSER, VERIFY_PARSER
+from .errors import HttpCortexLoginError
 from .httpcore import HttpCortex
 from .output import OUTP
 from .stormcli import start_storm_cli
@@ -65,10 +66,13 @@ async def main(argv: list[str]):
 
     username, password = get_cortex_creds(args.user)
 
-    async with HttpCortex(
-        args.cortex, username, password, ssl_verify=not args.no_verify
-    ) as hcore:
-        await start_storm_cli(hcore, outp=OUTP, opts=args, onecmd=args.onecmd)
+    try:
+        async with HttpCortex(
+            args.cortex, username, password, ssl_verify=not args.no_verify
+        ) as hcore:
+            await start_storm_cli(hcore, outp=OUTP, opts=args, onecmd=args.onecmd)
+    except HttpCortexLoginError as err:
+        return str(err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR does two things to gracefully exit on auth failures in `hstorm`:
1) Changes the `HttpCortex.login` method. It moves the original `login` functionality to a new method, `_login`, which the new `login` method calls. It also adds an optional `close` argument to the new `login` method, that defaults to `False`. When `True`, `HttpCortex.stop` is called when `_login` raises an exception, then `login` reraises that exception. This new argument is set to `True` in the `HttpCortex.__aenter__` method's `login` call.
2) A try/except is added to `hstorm.main` around the `HttpCortex` call and catches `HttpCortexLoginError` errors. This way only the error message is printed upon a login error.